### PR TITLE
Remove direct link to server manager from default index page.

### DIFF
--- a/default/usr/share/httpd/noindex/nethserver_index.html
+++ b/default/usr/share/httpd/noindex/nethserver_index.html
@@ -88,7 +88,7 @@ h2 {
   				</div>
                                 <div class="col-sm-6">
                                         <h2>Server Manager</h2>
-                                        <p>If you wish to configure you server, please access the <a href='/server-manager' onclick='window.location.href = "http://" + window.location.hostname + "/server-manager"; return false;'> Server Manager</a></p>
+                                        <p>If you wish to configure your server, please access the <a href='/server-manager' onclick='window.location.href = "http://" + window.location.hostname + "/server-manager"; return false;'> Server Manager</a></p>
                                 </div>
 
   				<div class="col-sm-6">

--- a/default/usr/share/httpd/noindex/nethserver_index.html
+++ b/default/usr/share/httpd/noindex/nethserver_index.html
@@ -88,7 +88,7 @@ h2 {
   				</div>
                                 <div class="col-sm-6">
                                         <h2>Server Manager</h2>
-                                        <p>If you wish to configure your server, please access the <a href='/server-manager' onclick='window.location.href = "http://" + window.location.hostname + "/server-manager"; return false;'> Server Manager</a></p>
+                                        <p>If you wish to configure your server, please access the Server Manager.  For help reaching the Server Manager, please consult the <a href="http://docs.nethserver.org/en/v7/access.html">documentation</a>.</p>
                                 </div>
 
   				<div class="col-sm-6">


### PR DESCRIPTION
As suggested in https://community.nethserver.org/t/remove-link-to-server-manager-from-welcome-page/9700, remove the direct link to the server manager from the default landing page.  Replace with a link to the manual.