### PR TITLE
ui. Split FTP empty state

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -53,6 +53,8 @@
     "ftp_is_disabled_desc": "Click on the button below to enable it",
     "enable_ftp": "Enable FTP server",
     "user_not_found": "No users found",
+    "configuration_updated_ok": "FTP configuration was updated",
+    "configuration_updated_error": "FTP configuration update error",
     "user_not_found_desc": "Click on the button below to create new one"
   },
   "virtualhost": {

--- a/ui/src/views/FTP.vue
+++ b/ui/src/views/FTP.vue
@@ -54,7 +54,7 @@
     <div v-show="view.menu.installed && view.isLoaded">
       <h3 v-if="configuration.status == 'enabled'">{{ $t('ftp.configuration') }}</h3>
 
-      <div v-if="configuration.status == 'disabled' && accounts.length > 0" class="blank-slate-pf">
+      <div v-if="configuration.status == 'disabled'" class="blank-slate-pf">
         <h1>{{$t('ftp.ftp_is_disabled')}}</h1>
         <p>{{$t('ftp.ftp_is_disabled_desc')}}.</p>
         <div class="blank-slate-pf-main-action">
@@ -64,6 +64,7 @@
           >{{$t('ftp.enable_ftp')}}</button>
         </div>
       </div>
+
       <div v-if="configuration.status == 'enabled'" class="panel panel-default">
         <div class="panel-heading">
           <toggle-button
@@ -83,7 +84,9 @@
           </span>
         </div>
       </div>
+    </div>
 
+    <div>
       <h3 v-if="accounts.length > 0">{{$t('ftp.actions')}}</h3>
       <div v-if="accounts.length > 0" class="btn-group">
         <button


### PR DESCRIPTION
The FTP enable switch must be always displayed, even when FTP is required only for virtual hosts.

Furthermore, the FTP switch must be more visible expecially when it is grayed-out in disabled state.

Even if an empty state is not an orthodox solution we decided to go with it.

https://github.com/NethServer/dev/issues/5778