### PR TITLE
systemd: quickly restart httpd

### DIFF
--- a/default/etc/systemd/system/httpd.service.d/quick_kill.conf
+++ b/default/etc/systemd/system/httpd.service.d/quick_kill.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStopSec=5


### PR DESCRIPTION
After some tests with `10` and `5` seconds timeout, I'd go with `5` since most web applications don't even notice connection problems.
As an example, with `10` seconds timeout, WebTop detect the connection problem and inform the user after the re-connection.

NethServer/dev#5816