### PR TITLE
Always open home page apps in https

### DIFF
--- a/default/usr/share/httpd/noindex/nethserver/res/system_apps.php
+++ b/default/usr/share/httpd/noindex/nethserver/res/system_apps.php
@@ -6,7 +6,8 @@
         http_response_code(404);
     } else {
         header('Content-type: application/json');
-        $systemApps = shell_exec('echo \'{"action":"list","location":{"hostname":"' . $_SERVER['SERVER_NAME'] . '"}}\' | /usr/bin/sudo /usr/libexec/nethserver/api/system-apps/read');
+
+        $systemApps = shell_exec('echo \'{"action":"list","location":{"hostname":"' . $_SERVER['SERVER_NAME'] . '", "protocol":"https:"}}\' | /usr/bin/sudo /usr/libexec/nethserver/api/system-apps/read');
         $systemAppsJson = json_decode($systemApps, true);
 
         if (is_null($systemAppsJson)) {
@@ -14,6 +15,9 @@
             echo json_encode([]);
         } else {
             foreach ($systemAppsJson as &$app) {
+                if (!array_key_exists('icon', $app)) {
+                    $app['icon'] = 'logo.png';
+                }
                 $iconUrl = $cockpitPath . $app['id'] . '/' . $app['icon'];
                 $iconData = file_get_contents($iconUrl);
                 $app['iconBase64'] = base64_encode($iconData);


### PR DESCRIPTION
- Home page apps now always open in https
- If an app manifest doesn't specify the icon, use "logo.png" as fallback

https://github.com/nethesis/dev/issues/5691