### PR TITLE
Improve reverse proxy "create" usability

### DIFF
--- a/ui/src/components/ModalProxypassVhostEdit.vue
+++ b/ui/src/components/ModalProxypassVhostEdit.vue
@@ -65,7 +65,7 @@ select {
 
         <div v-if="useCase == 'delete'" class="modal-body">
           <div
-            v-if="type === 'VhostReverse' || (name[0] !== '/' && name)"
+            v-if="formType === 'VhostReverse'"
             class="alert alert-info alert-dismissable"
           >
             <span class="pficon pficon-info"></span>
@@ -84,7 +84,7 @@ select {
 
         <div v-else class="modal-body">
           <div
-            v-if="(name[0] !== '/' && name && useCase !== 'edit')"
+            v-if="useCase === 'create' && formType === 'VhostReverse'"
             class="alert alert-info alert-dismissable"
           >
             <span class="pficon pficon-info"></span>
@@ -169,7 +169,7 @@ select {
 
               <!-- Certificate -->
               <div
-                v-if="type === 'VhostReverse' || (name[0] !== '/' && name)"
+                v-if="formType === 'VhostReverse'"
                 v-bind:class="['form-group', vErrors.SslCertificate ? 'has-error' : '']"
               >
                 <label
@@ -212,7 +212,7 @@ select {
 
               <!-- CertVerification-->
               <div
-                v-if="type === 'VhostReverse' || (name[0] !== '/' && name)"
+                v-if="formType === 'VhostReverse'"
                 v-bind:class="['form-group', vErrors.CertVerification ? 'has-error' : '']"
               >
                 <label
@@ -236,7 +236,7 @@ select {
 
               <!-- PreserveHost-->
               <div
-                v-if="type === 'VhostReverse' || (name[0] !== '/' && name)"
+                v-if="formType === 'VhostReverse'"
                 v-bind:class="['form-group', vErrors.PreserveHost ? 'has-error' : '']"
               >
                 <label
@@ -323,6 +323,15 @@ export default {
         this.ValidFrom = newval.ValidFrom.split(",").join("\n") || "";
       }
     }
+  },
+  computed: {
+      formType: function() {
+          if(this.useCase == 'create') {
+              return this.name[0] === '/' ? 'ProxyPass' : 'VhostReverse';
+          } else {
+              return this.proxypass.type;
+          }
+      },
   },
   data() {
     var obj = {


### PR DESCRIPTION
In the "create" scenario, some form fields are shown/hidden depending on
the first character typed in the Name field. If fields are initially
hidden, it is not clear what to do with Advanced settings.

As the "/" leading character to build a path rule is less common
(type=ProxyPass) and requires fewer fields than a host name matching
rule (type=VhostReverse) the PR initially displays the
form state for VhostReverse, with all available fields displayed.

Please see the issue for more information
https://github.com/NethServer/dev/issues/5999