### PR TITLE
New Web Server docs page

### DIFF
--- a/ui/src/views/FTP.vue
+++ b/ui/src/views/FTP.vue
@@ -26,8 +26,8 @@
     <doc-info
       :placement="'top'"
       :title="$t('docs.ftp')"
-      :chapter="'ftp'"
-      :section="''"
+      :chapter="'web_server'"
+      :section="'ftp-server'"
       :inline="false"
     ></doc-info>
 

--- a/ui/src/views/Proxypass.vue
+++ b/ui/src/views/Proxypass.vue
@@ -32,8 +32,8 @@
     <doc-info
       :placement="'top'"
       :title="$t('docs.Reverse_Proxy')"
-      :chapter="'proxy_pass'"
-      :section="''"
+      :chapter="'web_server'"
+      :section="'reverse-proxy'"
       :inline="false"
       :lang="'en'"
     ></doc-info>

--- a/ui/src/views/Virtualhosts.vue
+++ b/ui/src/views/Virtualhosts.vue
@@ -32,8 +32,8 @@
     <doc-info
       :placement="'top'"
       :title="$t('docs.virtualhost')"
-      :chapter="'virtual_hosts'"
-      :section="''"
+      :chapter="'web_server'"
+      :section="'virtual-hosts'"
       :inline="false"
       :lang="'en'"
     ></doc-info>


### PR DESCRIPTION
We just merged the PR with the new page about the Cockpti Web Server application

https://github.com/NethServer/docs/pull/464

This PR updates the `doc-info` links to point the new page.