### PR TITLE
Change default php memory_limit from 128 to 512

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ A new ``vhost`` database is defined by this module. It contains records of type
         PhpRhVersion=default
         PhpCustomSettings=disabled
         AllowUrlfOpen=enabled
-        MemoryLimit=128
+        MemoryLimit=512
         UploadMaxFilesize=4
         PostMaxSize=8
         MaxExecutionTime=0

--- a/api/virtualhost/read
+++ b/api/virtualhost/read
@@ -81,7 +81,7 @@ sub readVhost
         }
         if (!$props{'MemoryLimit'}) {
             # Default value for php
-            $props{'MemoryLimit'} = "128";
+            $props{'MemoryLimit'} = "512";
         }
         if (!$props{'UploadMaxFilesize'}) {
             # Default value for php

--- a/ui/src/views/Virtualhosts.vue
+++ b/ui/src/views/Virtualhosts.vue
@@ -231,7 +231,7 @@ export default {
         togglePass: false,
         PhpRhVersion: 'default',
         MaxExecutionTime: 0,
-        MemoryLimit: 128,
+        MemoryLimit: 512,
         PostMaxSize: 8,
         UploadMaxFilesize: 4,
         PhpCustomSettings: "disabled"

--- a/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php71/php-fpm.d/000-virtualhost.conf/10Base
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php71/php-fpm.d/000-virtualhost.conf/10Base
@@ -63,7 +63,7 @@ php_value[date.timezone] = $TimeZone
         if ($PhpCustomSettings eq 'enabled'){
 
             my $AllowUrlfOpen = $vdb->get_prop("$VhostName",'AllowUrlfOpen') || 'enabled';
-            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '128';
+            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '512';
             my $UpMaxFileSize = $vdb->get_prop("$VhostName",'UploadMaxFilesize') || '4';
             my $PostMaxSize = $vdb->get_prop("$VhostName",'PostMaxSize') || '8';
             my $MaxExecTime = $vdb->get_prop("$VhostName",'MaxExecutionTime') || '0';
@@ -78,7 +78,7 @@ php_value[date.timezone] = $TimeZone
             $OUT .= "php_admin_value[max_file_uploads] = $MaxFileUploads\n";
         } else {
 
-            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '128';
+            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '512';
             my $UpMaxFileSize = $db->get_prop('php','UploadMaxFilesize') || '4';
             my $PostMaxSize = $db->get_prop('php','PostMaxSize') || '8';
             my $MaxExecTime = $db->get_prop('php','MaxExecutionTime') || '0';

--- a/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php72/php-fpm.d/000-virtualhost.conf/10Base
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php72/php-fpm.d/000-virtualhost.conf/10Base
@@ -64,7 +64,7 @@ php_value[date.timezone] = $TimeZone
         if ($PhpCustomSettings eq 'enabled'){
 
             my $AllowUrlfOpen = $vdb->get_prop("$VhostName",'AllowUrlfOpen') || 'enabled';
-            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '128';
+            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '512';
             my $UpMaxFileSize = $vdb->get_prop("$VhostName",'UploadMaxFilesize') || '4';
             my $PostMaxSize = $vdb->get_prop("$VhostName",'PostMaxSize') || '8';
             my $MaxExecTime = $vdb->get_prop("$VhostName",'MaxExecutionTime') || '0';
@@ -79,7 +79,7 @@ php_value[date.timezone] = $TimeZone
             $OUT .= "php_admin_value[max_file_uploads] = $MaxFileUploads\n";
         } else {
 
-            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '128';
+            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '512';
             my $UpMaxFileSize = $db->get_prop('php','UploadMaxFilesize') || '4';
             my $PostMaxSize = $db->get_prop('php','PostMaxSize') || '8';
             my $MaxExecTime = $db->get_prop('php','MaxExecutionTime') || '0';

--- a/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php73/php-fpm.d/000-virtualhost.conf/10Base
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/rh/rh-php73/php-fpm.d/000-virtualhost.conf/10Base
@@ -64,7 +64,7 @@ php_value[date.timezone] = $TimeZone
         if ($PhpCustomSettings eq 'enabled'){
 
             my $AllowUrlfOpen = $vdb->get_prop("$VhostName",'AllowUrlfOpen') || 'enabled';
-            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '128';
+            my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '512';
             my $UpMaxFileSize = $vdb->get_prop("$VhostName",'UploadMaxFilesize') || '4';
             my $PostMaxSize = $vdb->get_prop("$VhostName",'PostMaxSize') || '8';
             my $MaxExecTime = $vdb->get_prop("$VhostName",'MaxExecutionTime') || '0';
@@ -79,7 +79,7 @@ php_value[date.timezone] = $TimeZone
             $OUT .= "php_admin_value[max_file_uploads] = $MaxFileUploads\n";
         } else {
 
-            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '128';
+            my $MemoryLimit = $db->get_prop('php','MemoryLimit') || '512';
             my $UpMaxFileSize = $db->get_prop('php','UploadMaxFilesize') || '4';
             my $PostMaxSize = $db->get_prop('php','PostMaxSize') || '8';
             my $MaxExecTime = $db->get_prop('php','MaxExecutionTime') || '0';

--- a/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/30directory21RhPhpAdminValues
+++ b/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/30directory21RhPhpAdminValues
@@ -8,7 +8,7 @@
     return ""  if (($PhpCustomSettings eq 'disabled') || ($PhpRhVersion ne 'default'));
 
     my $AllowUrlfOpen = $vdb->get_prop("$VhostName",'AllowUrlfOpen') || 'enabled';
-    my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '128';
+    my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '512';
     my $UpMaxFileSize = $vdb->get_prop("$VhostName",'UploadMaxFilesize') || '4';
     my $PostMaxSize = $vdb->get_prop("$VhostName",'PostMaxSize') || '8';
     my $MaxExecTime = $vdb->get_prop("$VhostName",'MaxExecutionTime') || '0';


### PR DESCRIPTION
Only for newer vhost we change the default memory from 128M to 512M

https://github.com/NethServer/dev/issues/6127