### PR TITLE
split is obsoleted in php, use explode

### DIFF
--- a/api/virtualhost/validate
+++ b/api/virtualhost/validate
@@ -73,7 +73,7 @@ if($data['virtualhost']['name'] != 'default') {
         }
         #Valid if the fqdn is not already used
         foreach ($vdb->getAll() as $key => $props) {
-            $vhost = split (",",$vdb->getProp($key, 'ServerNames'));
+            $vhost = explode (",",$vdb->getProp($key, 'ServerNames'));
             if ($key === $data['virtualhost']['name']) {
                 continue;
             }

--- a/api/virtualhost/validate
+++ b/api/virtualhost/validate
@@ -73,7 +73,7 @@ if($data['virtualhost']['name'] != 'default') {
         }
         #Valid if the fqdn is not already used
         foreach ($vdb->getAll() as $key => $props) {
-            $vhost = explode (",",$vdb->getProp($key, 'ServerNames'));
+            $vhost = explode(",", $vdb->getProp($key, 'ServerNames'));
             if ($key === $data['virtualhost']['name']) {
                 continue;
             }


### PR DESCRIPTION
Split is obsoleted with php7x, it is better to use explode

https://github.com/NethServer/dev/issues/6298