### PR TITLE
PHP80 SCL from remi

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -45,7 +45,7 @@ my $cmd = $input->{'action'};
 if ($cmd eq 'live') {
     
     my @phpSCL = ();
-    foreach (glob('/etc/e-smith/db/configuration/defaults/rh-php*-php-fpm')) {
+    foreach (glob('/etc/e-smith/db/configuration/defaults/*php*-php-fpm')) {
         $_ =~ s|/etc/e-smith/db/configuration/defaults/||;
         push @phpSCL, $_;
     }

--- a/api/lib/httpd_functions.pl
+++ b/api/lib/httpd_functions.pl
@@ -33,6 +33,7 @@ sub list_features
         'rh-php71-php-fpm' => { installed => (-f '/etc/e-smith/db/configuration/defaults/rh-php71-php-fpm/type') ? JSON::true : JSON::false, packages => ['nethserver-rh-php71-php-fpm'] },
         'rh-php72-php-fpm' => { installed => (-f '/etc/e-smith/db/configuration/defaults/rh-php72-php-fpm/type') ? JSON::true : JSON::false, packages => ['nethserver-rh-php72-php-fpm'] },
         'rh-php73-php-fpm' => { installed => (-f '/etc/e-smith/db/configuration/defaults/rh-php73-php-fpm/type') ? JSON::true : JSON::false, packages => ['nethserver-rh-php73-php-fpm'] },
+        'php80-php-fpm' => { installed => (-f '/etc/e-smith/db/configuration/defaults/php80-php-fpm/type') ? JSON::true : JSON::false, packages => ['nethserver-remi-php80-php-fpm'] },
         ftp => { installed => (-f '/etc/e-smith/db/configuration/defaults/vsftpd/type') ? JSON::true : JSON::false, packages => ['nethserver-vsftpd'] },
         logs => { installed => JSON::true, packages => ['nethserver-httpd'] },
         about => { installed => JSON::true, packages => ['nethserver-httpd'] },

--- a/api/virtualhost/read
+++ b/api/virtualhost/read
@@ -118,6 +118,7 @@ sub readVhost
     $ret->{'rhPhpScl'}->{'php71'} =  (-f '/etc/e-smith/db/configuration/defaults/rh-php71-php-fpm/type') ? JSON::true : JSON::false;
     $ret->{'rhPhpScl'}->{'php72'} =  (-f '/etc/e-smith/db/configuration/defaults/rh-php72-php-fpm/type') ? JSON::true : JSON::false;
     $ret->{'rhPhpScl'}->{'php73'} =  (-f '/etc/e-smith/db/configuration/defaults/rh-php73-php-fpm/type') ? JSON::true : JSON::false;
+    $ret->{'rhPhpScl'}->{'php80'} =  (-f '/etc/e-smith/db/configuration/defaults/php80-php-fpm/type') ? JSON::true : JSON::false;
 
     return $ret;
 }

--- a/api/virtualhost/validate
+++ b/api/virtualhost/validate
@@ -51,7 +51,7 @@ if($data['virtualhost']['name'] != 'default') {
         $v->declareParameter('PasswordValue', Validate::NOTEMPTY);
     }
     # phpSettings
-    $v->declareParameter('PhpRhVersion', $v->createValidator()->memberOf('default', 'php71', 'php72','php73'));
+    $v->declareParameter('PhpRhVersion', $v->createValidator()->memberOf('default', 'php71', 'php72','php73','php80'));
     $v->declareParameter('MaxExecutionTime', $v->createValidator()->integer()->greatThan(-1));
     $v->declareParameter('MemoryLimit', Validate::POSITIVE_INTEGER);
     $v->declareParameter('PostMaxSize', Validate::POSITIVE_INTEGER);

--- a/createlinks-virtualhosts
+++ b/createlinks-virtualhosts
@@ -122,6 +122,7 @@ for my $event (qw(
       /etc/opt/rh/rh-php71/php-fpm.d/000-virtualhost.conf
       /etc/opt/rh/rh-php72/php-fpm.d/000-virtualhost.conf
       /etc/opt/rh/rh-php73/php-fpm.d/000-virtualhost.conf
+      /etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf
 ));
 }
 
@@ -135,4 +136,5 @@ for my $event (qw(
     event_services($event, 'rh-php71-php-fpm' => 'restart');
     event_services($event, 'rh-php72-php-fpm' => 'restart');
     event_services($event, 'rh-php73-php-fpm' => 'restart');
+    event_services($event, 'php80-php-fpm' => 'restart');
 }

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -98,6 +98,7 @@
     "vsftpd_is_not_running": "the FTP service is not running",
     "default_php_version": "PHP 5.4 (default)",
     "php_version": "Version of PHP",
+    "php80_version": "PHP 8.0",
     "php73_version": "PHP 7.3",
     "php72_version": "PHP 7.2",
     "php71_version": "PHP 7.1 (obsolete)",
@@ -120,6 +121,7 @@
     "php_version_php71": "PHP 7.1 (obsolete)",
     "php_version_php72": "PHP 7.2",
     "php_version_php73": "PHP 7.3",
+    "php_version_php80": "PHP 8.0",
     "php_version_default": "PHP 5.4",
     "alert_php_obsoleted_title": "PHP 7.1 is obsolete",
     "alert_php_upgrade_php_detail": "You are strongly encouraged to use another PHP version, this software collection is not maintained anymore."

--- a/ui/src/components/ModalVhostEdit.vue
+++ b/ui/src/components/ModalVhostEdit.vue
@@ -386,6 +386,7 @@ select {
                     <option v-if="PhpRhVersion === 'php71'" value="php71">{{ $t('virtualhost.php71_version')}}</option>
                     <option value="php72">{{ $t('virtualhost.php72_version') + (hasPhpVersion('php72') ? '' : ' - ' + $t('virtualhost.option_php_not_installed')) }}</option>
                     <option value="php73">{{ $t('virtualhost.php73_version') + (hasPhpVersion('php73') ? '' : ' - ' + $t('virtualhost.option_php_not_installed')) }}</option>
+                    <option value="php80">{{ $t('virtualhost.php80_version') + (hasPhpVersion('php80') ? '' : ' - ' + $t('virtualhost.option_php_not_installed')) }}</option>
                   </select>
                   <span
                     v-if="vErrors.PhpRhVersion"

--- a/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/10Base
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/10Base
@@ -1,0 +1,95 @@
+{
+    use esmith::ConfigDB;
+    my $vdb = esmith::ConfigDB->open_ro('vhosts') || die("Can't open vhosts db");
+    my $db = esmith::ConfigDB->open_ro() || die("Can't open config db");
+
+    foreach my $vhost ($vdb->get_all_by_prop('type'=>'vhost')) {
+      
+        my $VhostName = $vhost->key;
+        my $status = $vhost->prop('status') || 'disabled';
+        my $PhpRhVersion = $vhost->prop('PhpRhVersion') ||' default';
+
+        #skip if vhost status is not enabled
+        if ($status ne 'enabled' ){
+          next;
+        }
+        #skip if vhost php version is not php80
+        if ($PhpRhVersion ne 'php80' ){
+          next;
+        }
+
+        my $PhpCustomSettings = $vhost->prop('PhpCustomSettings') || 'disabled';
+        my $ServerNames = $vhost->prop('ServerNames') || '';
+        $ServerNames =~ s/,/ /g;
+        my $TimeZone = $db->get_prop('php','DateTimezone') || 'UTC';
+
+        $OUT .= qq(
+;
+; vhosts $ServerNames
+;
+
+[$VhostName]
+listen = /var/run/$PhpRhVersion-php-fpm/$VhostName-$PhpRhVersion.sock
+
+;Logs
+php_admin_value[error_log] = /var/opt/remi/$PhpRhVersion/log/php-fpm/error-$VhostName.log
+php_admin_flag[log_errors] = on
+
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+
+user = apache;
+group = apache
+listen.owner = root
+listen.group = apache
+listen.mode = 0660
+
+; Set data paths to directories owned by process user
+php_value[session.save_handler] = files
+php_value[session.save_path]    = /var/opt/remi/$PhpRhVersion/lib/php/session
+php_value[soap.wsdl_cache_dir]  = /var/opt/remi/$PhpRhVersion/lib/php/wsdlcache
+
+
+; Set opcache settings per pool
+php_value[opcache.file_cache]  = /var/opt/remi/$PhpRhVersion/lib/php/opcache
+
+; default timezone
+php_value[date.timezone] = $TimeZone
+
+);
+
+        my $MemoryLimit = $vdb->get_prop("$VhostName",'MemoryLimit') || '512';
+        $OUT .= "php_admin_value[memory_limit] = $MemoryLimit"."M\n";
+
+        if ($PhpCustomSettings eq 'enabled'){
+
+            my $AllowUrlfOpen = $vdb->get_prop("$VhostName",'AllowUrlfOpen') || 'enabled';
+            my $UpMaxFileSize = $vdb->get_prop("$VhostName",'UploadMaxFilesize') || '4';
+            my $PostMaxSize = $vdb->get_prop("$VhostName",'PostMaxSize') || '8';
+            my $MaxExecTime = $vdb->get_prop("$VhostName",'MaxExecutionTime') || '0';
+            my $MaxFileUploads = $vdb->get_prop("$VhostName",'MaxFileUploads') || '20';
+
+            $OUT .= "php_admin_flag[allow_url_fopen] = off\n" if ($AllowUrlfOpen eq 'disabled');
+            $OUT .= "php_admin_value[upload_max_filesize] = $UpMaxFileSize"."M\n";
+            $OUT .= "php_admin_value[post_max_size] = $PostMaxSize"."M\n";
+            $OUT .= "php_admin_value[max_execution_time] = $MaxExecTime\n";
+            $OUT .= "php_admin_value[max_input_time] =  $MaxExecTime\n";
+            $OUT .= "php_admin_value[max_file_uploads] = $MaxFileUploads\n";
+        } else {
+
+            my $UpMaxFileSize = $db->get_prop('php','UploadMaxFilesize') || '4';
+            my $PostMaxSize = $db->get_prop('php','PostMaxSize') || '8';
+            my $MaxExecTime = $db->get_prop('php','MaxExecutionTime') || '0';
+            my $MaxFileUploads = $db->get_prop('php','MaxFileUploads') || '20';
+
+            $OUT .= "php_admin_value[upload_max_filesize] = $UpMaxFileSize"."M\n";
+            $OUT .= "php_admin_value[post_max_size] = $PostMaxSize"."M\n";
+            $OUT .= "php_admin_value[max_execution_time] = $MaxExecTime\n";
+            $OUT .= "php_admin_value[max_input_time] =  $MaxExecTime\n";
+            $OUT .= "php_admin_value[max_file_uploads] = $MaxFileUploads\n";
+        }
+    }
+}

--- a/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/10Base
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/10Base
@@ -29,7 +29,7 @@
 ;
 
 [$VhostName]
-listen = /var/run/$PhpRhVersion-php-fpm/$VhostName-$PhpRhVersion.sock
+listen = /var/run/rh-$PhpRhVersion-php-fpm/$VhostName-$PhpRhVersion.sock
 
 ;Logs
 php_admin_value[error_log] = /var/opt/remi/$PhpRhVersion/log/php-fpm/error-$VhostName.log

--- a/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/template-begin
+++ b/virtualhosts/etc/e-smith/templates/etc/opt/remi/php80/php-fpm.d/000-virtualhost.conf/template-begin
@@ -1,0 +1,9 @@
+;                  DO NOT MODIFY THIS FILE
+; Manual changes will be lost when this file is regenerated.
+;
+; Please read the developer's guide, which is available
+; at https://dev.nethesis.it/projects/nethserver/wiki/NethServer
+; original work from http://www.contribs.org/development/
+;
+; Copyright (C) 2020 Nethesis S.r.l. 
+; http://www.nethesis.it - support@nethesis.it

--- a/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
+++ b/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
@@ -10,9 +10,7 @@ if ($PhpVersion ne 'default')
     {
     # write the configuration
     $OUT .= "\n";
-    $OUT .= "# use rh-php-fpm with mod_proxy_fcgi by socket 
-# from rh repository  instead of the default PHP
-# PHP80 comes from remi repository\n";
+    $OUT .= "# Handle request with additional PHP-FPM backend from SCLo/Remi repositories\n";
     $OUT .= << "EOF";
 <FilesMatch \.php\$>
   SetHandler "proxy:unix:/var/run/rh-$PhpVersion-php-fpm/$VhostName-$PhpVersion.sock|fcgi://localhost"

--- a/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
+++ b/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
@@ -11,19 +11,12 @@ if ($PhpVersion ne 'default')
     # write the configuration
     $OUT .= "\n";
     $OUT .= "# use rh-php-fpm with mod_proxy_fcgi by socket 
-# from rh repository  instead of the default PHP\n";
-    if ($PhpVersion ne 'php80') {
-        $OUT .= << "EOF";
+# from rh repository  instead of the default PHP
+# PHP80 comes from remi repository\n";
+    $OUT .= << "EOF";
 <FilesMatch \.php\$>
   SetHandler "proxy:unix:/var/run/rh-$PhpVersion-php-fpm/$VhostName-$PhpVersion.sock|fcgi://localhost"
 </FilesMatch>
 EOF
-        } else {
-        $OUT .= << "EOF";
-<FilesMatch \.php\$>
-  SetHandler "proxy:unix:/var/run/$PhpVersion-php-fpm/$VhostName-$PhpVersion.sock|fcgi://localhost"
-</FilesMatch>
-EOF
-        }
     }
 }

--- a/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
+++ b/virtualhosts/etc/e-smith/templates/httpd/vhost-extra/15RhPhpScl_values
@@ -12,10 +12,18 @@ if ($PhpVersion ne 'default')
     $OUT .= "\n";
     $OUT .= "# use rh-php-fpm with mod_proxy_fcgi by socket 
 # from rh repository  instead of the default PHP\n";
-$OUT .= << "EOF";
+    if ($PhpVersion ne 'php80') {
+        $OUT .= << "EOF";
 <FilesMatch \.php\$>
   SetHandler "proxy:unix:/var/run/rh-$PhpVersion-php-fpm/$VhostName-$PhpVersion.sock|fcgi://localhost"
 </FilesMatch>
 EOF
+        } else {
+        $OUT .= << "EOF";
+<FilesMatch \.php\$>
+  SetHandler "proxy:unix:/var/run/$PhpVersion-php-fpm/$VhostName-$PhpVersion.sock|fcgi://localhost"
+</FilesMatch>
+EOF
+        }
     }
 }


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6356

This PR needs
- the remi-safe repository 
`yum install https://rpms.remirepo.net/enterprise/remi-release-7.rpm`
- the rpm `nethserver-remi-php80-php-fpm` the repository is at https://github.com/stephdl/nethserver-remi-php80-php-fpm


we have to find a way how to trade with the dependencies of php80 (SCL) from remi-safe