### PR TITLE
trusted-networks-modify triggers virtualhosts and httpd

### DIFF
--- a/createlinks-virtualhosts
+++ b/createlinks-virtualhosts
@@ -138,3 +138,12 @@ for my $event (qw(
     event_services($event, 'rh-php73-php-fpm' => 'restart');
     event_services($event, 'php80-php-fpm' => 'restart');
 }
+
+#--------------------------------------------------
+# templates for trusted-networks-modify event
+#--------------------------------------------------
+
+event_templates('trusted-networks-modify', qw(
+             /etc/httpd/conf.d/virtualhosts.conf
+));
+


### PR DESCRIPTION
trusted-networks-modify event should expand `/etc/httpd/conf.d/virtualhosts.conf` and restart httpd

https://github.com/NethServer/dev/issues/6712